### PR TITLE
Health beacon and garbage collection feature

### DIFF
--- a/packages/core/src/bridges/BroadcastChannelBridge.spec.ts
+++ b/packages/core/src/bridges/BroadcastChannelBridge.spec.ts
@@ -65,7 +65,7 @@ describe("BroadcastChannel Bridge tests", () => {
                 expect("Called message channel instead of state channel").toBe(message);
                 done();
             },
-            state: ({state: {metadata}}) => {
+            state: ({state: { metadata } = {}}) => {
                 expect(metadata).toBe(message);
                 done();
             },

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * @units ms
+ * @constant
+ */
+export const DEFAULT_BEACON_TIMER = 80;
+
+/**
+ * @units ms
+ * @constants
+ */
+export const DEFAULT_GARBAGE_COLLECTOR_TIMER = 20;
+
+/**
+ * @units ms
+ * @constants
+ */
+export const DEFAULT_REMOVE_AFTER_TIME = 200;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,13 @@ export type BroadcasterState<Metadata> = {
  *
  * @public
  */
-export type BroadcasterInstanceDescriptor<Metadata> = BroadcasterState<Metadata>;
+export type BroadcasterInstanceDescriptor<Metadata> = BroadcasterState<Metadata> & {
+    /**
+     * Broadcaster is inactive for specified amount of time
+     */
+    disabled?: boolean;
+    lastUpdate: number;
+};
 
 /**
  * An object representing public message from other broadcaster instance.
@@ -51,7 +57,7 @@ export type BroadcasterStateMessage<Metadata> = {
     /**
      * Owners state object.
      */
-    state: BroadcasterState<Metadata>;
+    state?: BroadcasterState<Metadata>;
     /**
      * Broadcaster ID, which will be used as a message address.
      */
@@ -80,6 +86,48 @@ export type BroadcasterSettings<Payload, Metadata> = {
      * Unique channel name, which will be used as a communication key
      */
     channel: string;
+
+    /**
+     * Broadcaster regularly sends health status messages.
+     * When some instance does not response for specified time,
+     * it will be considered as a dead instance and will be removed
+     * from broadcasters list.
+     *
+     * This option allows to disable this feature
+     */
+    disableGarbageCollector?: boolean;
+
+    /**
+     * Broadcaster regularly sends health status messages.
+     * When some instance does not response for specified time,
+     * it will be considered as a dead instance and will be removed
+     * from broadcasters list.
+     *
+     * This props sets a time after which broadcaster reference will be
+     * considered terminated and garbage collected.
+     *
+     * @units ms
+     * @default 200
+     */
+    garbageCollectorThresholdTimer?: number;
+
+    /**
+     * Interval in which Broadcasters health status will be checked
+     * and all of those which cross removal threshold will be deleted.
+     *
+     * @units ms
+     * @default 20
+     */
+    garbageCollectorTimer?: number;
+
+    /**
+     * Interval in which Broadcaster will periodically
+     * sends health status message
+     *
+     * @units ms
+     * @default 80
+     */
+    healthBeaconTimer?: number;
 
     /**
      * Initial metadata
@@ -137,4 +185,5 @@ export enum StateMessageType {
     CONNECTED,
     UPDATED,
     DISCONNECTED,
+    HEALTH_BEACON,
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -44,34 +44,9 @@ export const createBroadcaster = <Payload, Metadata>(
 ): ReactBroadcasterFactoryReturnType<Payload, Metadata> => {
     let broadcaster:Broadcaster<Payload, Metadata> | undefined = undefined;
 
-    /**
-     * Destroys Broadcasters connection with note to other instances
-     *
-     * @param event
-     * @returns
-     */
-    const closeBeforeUnload = (event: BeforeUnloadEvent): void => {
-        event.preventDefault();
-        event.stopPropagation();
-
-        broadcaster?.close();
-
-        return undefined;
-    };
-
     // register browser based event listeners
     broadcaster = new Broadcaster<Payload, Metadata>({
         ...settings,
-        on: {
-            init:(broadcasterInstance): void => {
-                window.addEventListener("beforeunload", closeBeforeUnload);
-                settings.on?.init?.(broadcasterInstance);
-            },
-            close: (broadcasterInstance): void => {
-                window.removeEventListener("beforeunload", closeBeforeUnload);
-                settings.on?.close?.(broadcasterInstance);
-            }
-        }
     });
 
     const useBroadcaster = createUseBroadcaster(broadcaster);


### PR DESCRIPTION
Instead of relying on window events (like beforeunload), which are inconsistent, we created a Garbage collector, which removes all instances, which are not active for specific time. Each broadcaster now periodically sends health status messages to keep connection alive. This feature can be disabled in settings. 

Window event detection can be added manually with lifecycle events in settings -> on.init and on.close.